### PR TITLE
Add CI Job to send the latest tag

### DIFF
--- a/.kapetanios/postsubmits.yaml
+++ b/.kapetanios/postsubmits.yaml
@@ -29,5 +29,6 @@ spec:
         - /app/cmd/pipectl/pipectl event register --api-key=`echo $API_KEY` --address=`echo $ADDRESS` --name=helm-release --labels helmRepo=pipecd --data=`echo $TAG`
       secrets:
       - name: dog_pipecd_api_key
+        type: PROJECT
       - name: dog_pipecd_address
         type: PROJECT

--- a/.kapetanios/postsubmits.yaml
+++ b/.kapetanios/postsubmits.yaml
@@ -14,3 +14,20 @@ spec:
       secrets:
       - name: chart_releaser_service_account
         type: PROJECT
+
+  - name: register-event
+    timeout: 30m
+    machine:
+      resource: small
+    steps:
+    - description: Register a new Event to PipeCD control-plane
+      runner: gcr.io/pipecd/pipectl:v0.9.5-15-g576b88a
+      commands:
+        - export TAG=`git describe --tags`
+        - export API_KEY=`cat /secrets/dog_pipecd_api_key`
+        - export ADDRESS=`cat /secrets/dog_pipecd_address`
+        - /app/cmd/pipectl/pipectl event register --api-key=`echo $API_KEY` --address=`echo $ADDRESS` --name=helm-release --labels helmRepo=pipecd --data=`echo $TAG`
+      secrets:
+      - name: dog_pipecd_api_key
+      - name: dog_pipecd_address
+        type: PROJECT


### PR DESCRIPTION
Upon the `--api-key-file` option is supported, I'd be happy to replace the `-api-key` flag with it.