### PR TITLE
Skip running register-event build on pull request events

### DIFF
--- a/.kapetanios/postsubmits.yaml
+++ b/.kapetanios/postsubmits.yaml
@@ -19,6 +19,8 @@ spec:
     timeout: 30m
     machine:
       resource: small
+    skipBranches:
+      - ".*"
     steps:
     - description: Register a new Event to PipeCD control-plane
       runner: gcr.io/pipecd/pipectl:v0.9.5-22-gbd6e347


### PR DESCRIPTION
Currently, whenever a new pull request is opened (or a new commit is pushed to a branch), `register-event` will be triggered.